### PR TITLE
feat(docs): Create extended CLI syntax documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         example: ${{ fromJson(needs.discover.outputs.examples) }}
         fqbn: [arduino:avr:uno, arduino:mbed_rp2040:pico]
+        cli_syntax: [short, long]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -35,12 +36,18 @@ jobs:
           arduino-cli core install arduino:mbed_rp2040
       - name: Compile sketch
         run: |
-          arduino-cli compile --fqbn ${{ matrix.fqbn }} arduino_examples/${{ matrix.example }} --output-dir build/${{ matrix.example }}-${{ matrix.fqbn }}
+          BUILD_PROPERTIES=""
+          if [ "${{ matrix.cli_syntax }}" == "long" ]; then
+            BUILD_PROPERTIES="--build-property build.extra_flags=-DUSE_EXTENDED_CLI_SYNTAX=1"
+          else
+            BUILD_PROPERTIES="--build-property build.extra_flags=-DUSE_EXTENDED_CLI_SYNTAX=0"
+          fi
+          arduino-cli compile --fqbn ${{ matrix.fqbn }} $BUILD_PROPERTIES arduino_examples/${{ matrix.example }} --output-dir build/${{ matrix.example }}-${{ matrix.fqbn }}-${{ matrix.cli_syntax }}
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.example }}-${{ matrix.fqbn }}
-          path: build/${{ matrix.example }}-${{ matrix.fqbn }}
+          name: ${{ matrix.example }}-${{ matrix.fqbn }}-${{ matrix.cli_syntax }}
+          path: build/${{ matrix.example }}-${{ matrix.fqbn }}-${{ matrix.cli_syntax }}
 
   release:
     needs: build

--- a/docs/EXTENDED_CLI_SYNTAX.md
+++ b/docs/EXTENDED_CLI_SYNTAX.md
@@ -4,6 +4,8 @@ This document defines the extended command-line interface (CLI) syntax for the x
 
 The extended syntax follows a consistent format: `<COMMAND param1="value1" param2="value2" ...>`.
 
+**Note on Command Formats:** The `CmdLineParser` class is designed to accept both the legacy single-character commands and the extended commands at all times. The `CmdLinePrinter` class, however, can be configured to output either the legacy or extended format. This is controlled by the `USE_EXTENDED_CLI_SYNTAX` compile-time flag. By default, the extended syntax is used for output. To use the legacy syntax for output, set this flag to `0` during compilation.
+
 ## A. Track Power & Status
 
 | Command | Legacy | Parameters | Description | Example |


### PR DESCRIPTION
This commit introduces a new document, `EXTENDED_CLI_SYNTAX.md`, which provides a more self-descriptive and user-friendly command syntax for the xDuinoRails_xTrainAPI.

The new syntax extends the existing DCC-EX commands with multi-character alternatives and covers all events in the `IUnifiedModelTrainListener` interface, proposing new commands where necessary to ensure complete API coverage.