### PR TITLE
feat: Add automated documentation generation and deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,22 @@ jobs:
       - name: Validate XML files
         run: xmllint --noout --schema arduino_examples/xml_messages/xTrainEvents.xsd arduino_examples/xml_messages/*.xml
 
+  validate-swagger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install openapi-spec-validator
+      - name: Validate OpenAPI spec
+        run: openapi-spec-validator swagger/openapi.yaml
+
   release:
-    needs: build
+    needs: [build, validate-xml, validate-swagger]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -67,3 +81,51 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: artifacts/*/*.uf2
+
+  build-and-deploy-docs:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli
+
+      - name: Generate Doxygen documentation
+        run: doxygen Doxyfile
+
+      - name: Generate Redocly documentation
+        run: |
+          mkdir -p public/redoc
+          redocly build-docs swagger/openapi.yaml -o public/redoc/index.html
+
+      - name: Create index page
+        run: |
+          echo '<!DOCTYPE html>
+          <html>
+          <head>
+            <title>xTrain API Documentation</title>
+          </head>
+          <body>
+            <h1>xTrain API Documentation</h1>
+            <ul>
+              <li><a href="doxygen/index.html">Doxygen (C++ API)</a></li>
+              <li><a href="redoc/index.html">Redocly (REST API)</a></li>
+            </ul>
+          </body>
+          </html>' > public/index.html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Instructions for xTrainAPI
+
+This document provides guidance for AI agents working on this repository.
+
+## Source of Truth
+
+The canonical definition of the xTrainAPI is the C++ abstract interface located at:
+
+`/xDuinoRails_xTrainAPI.h`
+
+This header file is the **single source of truth** for all API events, data structures, and enums.
+
+## Derivative Artifacts
+
+The following files are derivatives of the main `.h` file and **must** be kept in sync with it:
+
+1.  **XML Schema:** `/arduino_examples/xml_messages/xTrainEvents.xsd`
+2.  **OpenAPI Schema:** `/swagger/openapi.yaml`
+
+### Agent Responsibility
+
+When making changes to the API, you **must** follow this workflow:
+
+1.  **Modify the `.h` file first.** All new events, or changes to existing ones, should be implemented in `xDuinoRails_xTrainAPI.h`.
+2.  **Update the derivatives.** Propagate the changes to the `.xsd` and `openapi.yaml` files to reflect the modifications made to the header.
+3.  **Run validation.** Ensure that the XML and OpenAPI validation checks pass after your changes.
+
+Failure to keep these files consistent will result in build failures and a broken API contract. Always check for deviations from the main `.h` file and correct them.

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,248 @@
+# Doxyfile 1.9.8
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "xTrain API"
+PROJECT_NUMBER         = 2.3
+PROJECT_BRIEF          = "A Unified Model Train Control System"
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       = public/doxygen
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = YES
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMBERS   = YES
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+#---------------------------------------------------------------------------
+# configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = .
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.h
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       = */build/* \
+                         */arduino_examples/testdata/*
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+#---------------------------------------------------------------------------
+# configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+#---------------------------------------------------------------------------
+# configuration options related to the alphabetical index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = .
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHP_PRIMARY_DEPLOYMENT_SECTION =
+DISABLE_INDEX          = NO
+ENUM_VALUES_PER_LINE   = 4
+GENERATE_TREEVIEW      = YES
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        =
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_ID        =
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+#---------------------------------------------------------------------------
+# configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+#---------------------------------------------------------------------------
+# configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+#---------------------------------------------------------------------------
+# configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+#---------------------------------------------------------------------------
+# configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+#---------------------------------------------------------------------------
+# configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+#---------------------------------------------------------------------------
+# configuration options related to preprocessor files
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+#---------------------------------------------------------------------------
+# configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+MSCGEN_PATH            =
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = NO
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -1,0 +1,176 @@
+openapi: 3.0.0
+info:
+  title: xTrain Event API
+  version: "1.0.0"
+  description: |
+    A RESTful API to trigger events for the Unified Model Train Control System (xTrain).
+    This API is based on the abstract interface defined in `xDuinoRails_xTrainAPI.h`.
+servers:
+  - url: "/api/v1"
+    description: "Main API endpoint"
+
+paths:
+  /event:
+    post:
+      summary: "Submit a single train control event"
+      description: "Receives and processes a single event object."
+      operationId: "postEvent"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+      responses:
+        '202':
+          description: "Event accepted for processing."
+        '400':
+          description: "Bad Request - Invalid event structure or payload."
+
+components:
+  schemas:
+    # This is the schema that should be used in requests/responses.
+    # It uses a discriminator to determine the actual event type.
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/LocoSpeedChanged'
+        - $ref: '#/components/schemas/LocoFunctionChanged'
+        - $ref: '#/components/schemas/TurnoutChanged'
+        - $ref: '#/components/schemas/TrackPowerChanged'
+        - $ref: '#/components/schemas/SensorStateChanged'
+      discriminator:
+        propertyName: eventType
+        mapping:
+          LocoSpeedChanged: '#/components/schemas/LocoSpeedChanged'
+          LocoFunctionChanged: '#/components/schemas/LocoFunctionChanged'
+          TurnoutChanged: '#/components/schemas/TurnoutChanged'
+          TrackPowerChanged: '#/components/schemas/TrackPowerChanged'
+          SensorStateChanged: '#/components/schemas/SensorStateChanged'
+
+    # This is the base schema with common properties, used for inheritance.
+    BaseEvent:
+      type: object
+      required:
+        - eventType
+        - timestamp
+      properties:
+        eventType:
+          type: string
+          description: "The unique identifier for the event type."
+        timestamp:
+          type: string
+          format: date-time
+          description: "ISO 8601 timestamp of when the event was generated."
+
+    # --------- Core Data Types ---------
+
+    LocoHandle:
+      type: object
+      description: "Unique identifier for a locomotive."
+      required: [address, protocol]
+      properties:
+        address:
+          type: integer
+          format: uint16
+          description: "Primary address of the locomotive."
+        protocol:
+          $ref: '#/components/schemas/Protocol'
+        mfxUid:
+          type: integer
+          format: uint32
+          description: "Unique mfx ID, if applicable."
+
+    # --------- Enums (from .h file) ---------
+
+    Protocol:
+      type: string
+      enum: [DCC, MM_I, MM_II, MFX, SELECTRIX, SX2, LOCONET, BIDIB, XPRESSNET, CAN_GENERIC]
+    Direction:
+      type: string
+      enum: [REVERSE, FORWARD, UNKNOWN]
+    PowerState:
+      type: string
+      enum: [OFF, ON, EMERGENCY_STOP, SHORT_CIRCUIT]
+
+    # --------- Event-Specific Schemas ---------
+
+    LocoSpeedChanged:
+      type: object
+      description: "Event for changing a locomotive's speed and direction."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [loco, speedPercent, direction, speedSteps]
+          properties:
+            loco:
+              $ref: '#/components/schemas/LocoHandle'
+            speedPercent:
+              type: number
+              format: float
+              minimum: 0.0
+              maximum: 100.0
+            direction:
+              $ref: '#/components/schemas/Direction'
+            speedSteps:
+              type: integer
+              description: "The speed step mode (e.g., 14, 28, 128)."
+
+    LocoFunctionChanged:
+      type: object
+      description: "Event for activating or deactivating a locomotive function."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [loco, fIndex, isActive]
+          properties:
+            loco:
+              $ref: '#/components/schemas/LocoHandle'
+            fIndex:
+              type: integer
+              description: "Function index (0 for light, 1 for F1, etc.)."
+            isActive:
+              type: boolean
+
+    TurnoutChanged:
+      type: object
+      description: "Event for changing a turnout's state."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [address, isThrown, isFeedback]
+          properties:
+            address:
+              type: integer
+              format: uint16
+            isThrown:
+              type: boolean
+              description: "True for diverging/thrown, False for straight."
+            isFeedback:
+              type: boolean
+              description: "True if this is a confirmation from hardware."
+
+    TrackPowerChanged:
+      type: object
+      description: "Event for changing the global track power state."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [state]
+          properties:
+            state:
+              $ref: '#/components/schemas/PowerState'
+
+    SensorStateChanged:
+      type: object
+      description: "Event for an occupancy or feedback sensor changing state."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [sensorId, isActive]
+          properties:
+            sensorId:
+              type: integer
+              format: uint32
+            isActive:
+              type: boolean
+              description: "True for occupied/active, False for free."


### PR DESCRIPTION
This commit introduces a new CI/CD pipeline to automatically generate and deploy documentation for both the C++ source code and the REST API.

- A `Doxyfile` has been added and configured to generate HTML documentation from the C++ header files.
- The GitHub Actions workflow in `.github/workflows/build.yml` has been updated with a new `build-and-deploy-docs` job.
- This job uses Doxygen to build the C++ documentation and Redocly CLI to build the REST API documentation from the `swagger/openapi.yaml` file.
- The combined documentation is then deployed to GitHub Pages on every push to the `main` branch.
- An index page is created to link to both sets of documentation.