### PR TITLE
feat: Add German README.md and project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,7 @@ When making changes to the API, you **must** follow this workflow:
 3.  **Run validation.** Ensure that the XML and OpenAPI validation checks pass after your changes.
 
 Failure to keep these files consistent will result in build failures and a broken API contract. Always check for deviations from the main `.h` file and correct them.
+
+## File Naming Conventions
+
+Documentation files should be in `UPPER_SNAKE_CASE` (e.g., `DATA_DICTIONARY.md`). Standard files like `README.md`, `AGENTS.md`, and `LICENSE` are exceptions to this rule.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# xTrainAPI - Einheitliche Modellbahnsteuerung
+
+Willkommen beim xTrainAPI-Projekt! Dieses Repository enthält eine C++-basierte API zur Steuerung von digitalen Modelleisenbahnen und deren Zubehör.
+
+## Dokumentation
+
+Unsere API-Dokumentation wird automatisch generiert und auf GitHub Pages gehostet.
+
+*   **Doxygen (C++ API):** Eine detaillierte Dokumentation des C++-Interfaces, der Klassen und Methoden finden Sie hier:
+    [Doxygen-Dokumentation](https://xtrainapi.github.io/xTrainAPI/doxygen/)
+
+*   **Swagger (REST API):** Die Spezifikation unserer REST-Schnittstelle, inklusive interaktiver Endpunkte, ist hier verfügbar:
+    [Swagger UI](https://xtrainapi.github.io/xTrainAPI/swagger/)
+
+## Was ist xTrainAPI?
+
+xTrainAPI ist eine vereinheitlichte Schnittstelle, die es ermöglicht, verschiedene digitale Modellbahnsysteme über ein einziges, konsistentes API zu steuern. Dies vereinfacht die Entwicklung von Steuerungssoftware, da die Komplexität der einzelnen Protokolle (wie DCC, Märklin Motorola, etc.) abstrahiert wird.
+
+## Kernkonzepte
+
+Die API ist in C++ als abstrakte Schnittstelle (`IUnifiedModelTrainListener`) definiert und dient als "Single Source of Truth". Alle anderen Artefakte, wie die XML-Schemata und die OpenAPI-Spezifikation, werden von dieser C++-Header-Datei abgeleitet.
+
+Für ein tieferes Verständnis der in der API verwendeten Begriffe und Datenfelder, werfen Sie bitte einen Blick in unser [Glossar](XTTRAIN_GLOSSARY.md) und das [Data Dictionary](DATA_DICTIONARY.md).
+
+## Mitwirken
+
+Wir freuen uns über Beiträge! Bitte lesen Sie unsere `AGENTS.md`, bevor Sie Änderungen am Code vornehmen.


### PR DESCRIPTION
This commit introduces a comprehensive `README.md` file in German to serve as the main entry point for the repository. The new file includes a project description and direct links to the Doxygen and Swagger documentation hosted on GitHub Pages.

Additionally, this change updates `AGENTS.md` to establish a clear file naming convention for documentation files, requiring `UPPER_SNAKE_CASE` for new documents while exempting standard files like `README.md`. This change incorporates feedback from code reviews to ensure correctness and consistency.