### PR TITLE
fix(ci): create doxygen output directory before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Install Redocly CLI
         run: npm install -g @redocly/cli
 
+      - name: Create Doxygen output directory
+        run: mkdir -p public/doxygen
+
       - name: Generate Doxygen documentation
         run: doxygen Doxyfile
 


### PR DESCRIPTION
The documentation build was failing because the output directory specified in the Doxyfile ('public/doxygen') did not exist.

This change adds a step to the GitHub Actions workflow to create the directory before running Doxygen, resolving the fatal error.