### PR TITLE
feat(api): Add CV read and write request events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This header file is the **single source of truth** for all API events, data stru
 
 The following files are derivatives of the main `.h` file and **must** be kept in sync with it:
 
-1.  **XML Schema:** `/arduino_examples/xml_messages/xTrainEvents.xsd`
+1.  **XML Schema:** `/xml/xTrainEvents.xsd`
 2.  **OpenAPI Schema:** `/swagger/openapi.yaml`
 
 ### Agent Responsibility

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -38,6 +38,8 @@ components:
         - $ref: '#/components/schemas/TurnoutChanged'
         - $ref: '#/components/schemas/TrackPowerChanged'
         - $ref: '#/components/schemas/SensorStateChanged'
+        - $ref: '#/components/schemas/CvWriteRequest'
+        - $ref: '#/components/schemas/CvReadRequest'
       discriminator:
         propertyName: eventType
         mapping:
@@ -46,6 +48,8 @@ components:
           TurnoutChanged: '#/components/schemas/TurnoutChanged'
           TrackPowerChanged: '#/components/schemas/TrackPowerChanged'
           SensorStateChanged: '#/components/schemas/SensorStateChanged'
+          CvWriteRequest: '#/components/schemas/CvWriteRequest'
+          CvReadRequest: '#/components/schemas/CvReadRequest'
 
     # This is the base schema with common properties, used for inheritance.
     BaseEvent:
@@ -174,3 +178,35 @@ components:
             isActive:
               type: boolean
               description: "True for occupied/active, False for free."
+
+    CvWriteRequest:
+      type: object
+      description: "Request to write a value to a configuration variable (CV)."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [loco, cvNumber, value]
+          properties:
+            loco:
+              $ref: '#/components/schemas/LocoHandle'
+            cvNumber:
+              type: integer
+              description: "The CV number to write to."
+            value:
+              type: integer
+              format: uint8
+              description: "The 8-bit value to write."
+
+    CvReadRequest:
+      type: object
+      description: "Request to read a value from a configuration variable (CV)."
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [loco, cvNumber]
+          properties:
+            loco:
+              $ref: '#/components/schemas/LocoHandle'
+            cvNumber:
+              type: integer
+              description: "The CV number to read from."

--- a/xDuinoRails_xTrainAPI.h
+++ b/xDuinoRails_xTrainAPI.h
@@ -252,6 +252,8 @@ namespace ModelRail {
         // GROUP E: CONFIGURATION & MASS DATA
         // -------------------------------------------------------------
 
+        virtual void onCvReadRequest(const LocoHandle& loco, int cvNumber)                                               = 0;
+        virtual void onCvWriteRequest(const LocoHandle& loco, int cvNumber, uint8_t value)                                = 0;
         virtual void onCvReadResult(const LocoHandle& loco, int cvNumber, uint8_t value, bool success)                   = 0;
         virtual void onSusiConfigRead(const LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value)       = 0;
         

--- a/xml/xTrainEvents.xsd
+++ b/xml/xTrainEvents.xsd
@@ -123,8 +123,8 @@
 
     <xs:complexType name="CvType">
         <xs:attribute name="cvNumber" type="xs:positiveInteger" use="required"/>
-        <xs:attribute name="value" type="xs:unsignedByte" use="required"/>
-        <xs:attribute name="success" type="xs:boolean" use="required"/>
+        <xs:attribute name="value" type="xs:unsignedByte" use="optional"/>
+        <xs:attribute name="success" type="xs:boolean" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="ProgressType">


### PR DESCRIPTION
Adds new events to the xTrainAPI, `onCvReadRequest` and `onCvWriteRequest`, to allow clients to request reading from and writing to configuration variables (CVs).

This change includes:
- Adding the virtual functions `onCvReadRequest` and `onCvWriteRequest` to the `IUnifiedModelTrainListener` interface in `xDuinoRails_xTrainAPI.h`.
- Updating the XML schema (`xml/xTrainEvents.xsd`) to make the `value` and `success` attributes in `CvType` optional, allowing it to be used for read requests, write requests, and read results.
- Updating the OpenAPI specification (`swagger/openapi.yaml`) to include new `CvReadRequest` and `CvWriteRequest` events.
- Correcting a file path to the XSD schema in `AGENTS.md`.