### PR TITLE
ci: grant write permission to gh-pages job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,8 @@ jobs:
     # must be configured to serve from the 'gh-pages' branch.
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
The `build-and-deploy-docs` job was failing with a 403 permission error because the `GITHUB_TOKEN` lacked the necessary permissions to push to the `gh-pages` branch. This change adds the `permissions: contents: write` block to the job to grant the required access.