### PR TITLE
feat: Add missing XML event examples

### DIFF
--- a/xml/all_messages.xml
+++ b/xml/all_messages.xml
@@ -35,6 +35,11 @@
         <consist type="ADVANCED_DCC" inverted="false" />
     </event>
 
+    <!-- Event: A locomotive has been removed from a consist. -->
+    <event type="onConsistUnlink" timestamp="2024-07-29T10:03:00Z">
+        <slave address="2002" protocol="DCC" />
+    </event>
+
     <!-- ===================================================================== -->
     <!-- GROUP B: INFRASTRUCTURE (ACCESSORIES)                                 -->
     <!-- ===================================================================== -->
@@ -83,6 +88,16 @@
         <node nodeUid="BIDIB-0A3B5" productName="LightControl" booster="false" />
     </event>
 
+    <!-- Event: A hardware node has disconnected from the bus. -->
+    <event type="onHardwareNodeLost" timestamp="2024-07-29T10:04:00Z">
+        <node nodeUid="booster-2" productName="Unknown" booster="true" />
+    </event>
+
+    <!-- Event: A generic system message or log entry. -->
+    <event type="onSystemMessage" timestamp="2024-07-29T10:05:00Z">
+        <message source="PowerManager" text="Emergency stop triggered by user." />
+    </event>
+
     <!-- ===================================================================== -->
     <!-- GROUP D: TELEMETRY & IDENTIFICATION                                   -->
     <!-- ===================================================================== -->
@@ -106,6 +121,18 @@
         <externalState state="STOPPED_BY_ABC_SIGNAL" />
     </event>
 
+    <!-- Event: Raw/Proprietary RailCom Data. -->
+    <event type="onLocoRailComRawData" timestamp="2024-07-29T10:06:00Z">
+        <loco address="1024" protocol="DCC" />
+        <railcom app="1" data="01A4B7" />
+    </event>
+
+    <!-- Event: A new locomotive was discovered (mfx / RailComPlus). -->
+    <event type="onNewLocoDiscovered" timestamp="2024-07-29T10:07:00Z">
+        <loco mfxUid="12345678" protocol="MFX" address="1" />
+        <discovery name="BR 18.5" icon="br18.png" />
+    </event>
+
     <!-- ===================================================================== -->
     <!-- GROUP E: CONFIGURATION & MASS DATA                                    -->
     <!-- ===================================================================== -->
@@ -116,8 +143,43 @@
         <cv cvNumber="5" value="200" success="true" />
     </event>
 
+    <!-- Event: A request to read a CV from a decoder has been issued. -->
+    <event type="onCvReadRequest" timestamp="2024-07-29T10:08:00Z">
+        <loco address="3" protocol="DCC" />
+        <cv cvNumber="5" />
+    </event>
+
+    <!-- Event: A request to write a CV to a decoder has been issued. -->
+    <event type="onCvWriteRequest" timestamp="2024-07-29T10:09:00Z">
+        <loco address="3" protocol="DCC" />
+        <cv cvNumber="5" value="128" />
+    </event>
+
+    <!-- Event: Result of reading a SUSI configuration register. -->
+    <event type="onSusiConfigRead" timestamp="2024-07-29T10:10:00Z">
+        <loco address="4" protocol="DCC" />
+        <susi bank="1" index="2" value="3" />
+    </event>
+
+    <!-- Event: Mass Data Transfer (e.g., icon or sound profile). -->
+    <event type="onConfigBlockLoaded" timestamp="2024-07-29T10:11:00Z">
+        <loco address="5" protocol="DCC" />
+        <config domain="ICON" data="89504e47" />
+    </event>
+
     <!-- Event: A progress update for a long-running operation. -->
     <event type="onProgressUpdate" timestamp="2024-07-29T10:09:05Z">
         <progress operation="Reading Decoder CVs" percent="25.0" />
     </event>
+
+    <!-- ===================================================================== -->
+    <!-- GROUP F: REAL-TIME SYNCHRONIZATION (v2.3+)                            -->
+    <!-- ===================================================================== -->
+
+    <!-- Event: A mechanical synchronization event occurred. -->
+    <event type="onLocoSyncEvent" timestamp="2024-07-29T10:12:00Z">
+        <loco address="6" protocol="DCC" />
+        <sync type="CAM_PULSE" value="1" />
+    </event>
+
 </xTrainEvents>

--- a/xml/onConfigBlockLoaded.xml
+++ b/xml/onConfigBlockLoaded.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onConfigBlockLoaded" timestamp="2024-07-29T10:11:00Z">
+        <loco address="5" protocol="DCC" />
+        <config domain="ICON" data="89504e47" />
+    </event>
+</xTrainEvents>

--- a/xml/onConsistUnlink.xml
+++ b/xml/onConsistUnlink.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onConsistUnlink" timestamp="2024-07-29T10:03:00Z">
+        <slave address="2002" protocol="DCC" />
+    </event>
+</xTrainEvents>

--- a/xml/onCvReadRequest.xml
+++ b/xml/onCvReadRequest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onCvReadRequest" timestamp="2024-07-29T10:08:00Z">
+        <loco address="3" protocol="DCC" />
+        <cv cvNumber="5" />
+    </event>
+</xTrainEvents>

--- a/xml/onCvWriteRequest.xml
+++ b/xml/onCvWriteRequest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onCvWriteRequest" timestamp="2024-07-29T10:09:00Z">
+        <loco address="3" protocol="DCC" />
+        <cv cvNumber="5" value="128" />
+    </event>
+</xTrainEvents>

--- a/xml/onHardwareNodeLost.xml
+++ b/xml/onHardwareNodeLost.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onHardwareNodeLost" timestamp="2024-07-29T10:04:00Z">
+        <node nodeUid="booster-2" productName="Unknown" booster="true" />
+    </event>
+</xTrainEvents>

--- a/xml/onLocoRailComRawData.xml
+++ b/xml/onLocoRailComRawData.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onLocoRailComRawData" timestamp="2024-07-29T10:06:00Z">
+        <loco address="1024" protocol="DCC" />
+        <railcom app="1" data="01A4B7" />
+    </event>
+</xTrainEvents>

--- a/xml/onLocoSyncEvent.xml
+++ b/xml/onLocoSyncEvent.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onLocoSyncEvent" timestamp="2024-07-29T10:12:00Z">
+        <loco address="6" protocol="DCC" />
+        <sync type="CAM_PULSE" value="1" />
+    </event>
+</xTrainEvents>

--- a/xml/onNewLocoDiscovered.xml
+++ b/xml/onNewLocoDiscovered.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onNewLocoDiscovered" timestamp="2024-07-29T10:07:00Z">
+        <loco mfxUid="12345678" protocol="MFX" address="1" />
+        <discovery name="BR 18.5" icon="br18.png" />
+    </event>
+</xTrainEvents>

--- a/xml/onSusiConfigRead.xml
+++ b/xml/onSusiConfigRead.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onSusiConfigRead" timestamp="2024-07-29T10:10:00Z">
+        <loco address="4" protocol="DCC" />
+        <susi bank="1" index="2" value="3" />
+    </event>
+</xTrainEvents>

--- a/xml/onSystemMessage.xml
+++ b/xml/onSystemMessage.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onSystemMessage" timestamp="2024-07-29T10:05:00Z">
+        <message source="PowerManager" text="Emergency stop triggered by user." />
+    </event>
+</xTrainEvents>

--- a/xml/xTrainEvents.xsd
+++ b/xml/xTrainEvents.xsd
@@ -34,6 +34,12 @@
                 <xs:element name="externalState" type="ExternalStateType"/>
                 <xs:element name="cv" type="CvType"/>
                 <xs:element name="progress" type="ProgressType"/>
+                <xs:element name="message" type="MessageType"/>
+                <xs:element name="railcom" type="RailComType"/>
+                <xs:element name="discovery" type="DiscoveryType"/>
+                <xs:element name="susi" type="SusiType"/>
+                <xs:element name="config" type="ConfigType"/>
+                <xs:element name="sync" type="SyncType"/>
             </xs:choice>
         </xs:sequence>
         <xs:attribute name="type" type="xs:string" use="required"/>
@@ -42,7 +48,7 @@
 
     <!-- Complex Type Definitions for Event Payloads -->
     <xs:complexType name="LocoHandleType">
-        <xs:attribute name="address" type="xs:positiveInteger" use="required"/>
+        <xs:attribute name="address" type="xs:positiveInteger" use="optional"/>
         <xs:attribute name="protocol" type="ProtocolEnum" use="required"/>
         <xs:attribute name="mfxUid" type="xs:unsignedInt" use="optional"/>
     </xs:complexType>
@@ -132,6 +138,37 @@
         <xs:attribute name="percent" type="xs:float" use="required"/>
     </xs:complexType>
 
+    <xs:complexType name="MessageType">
+        <xs:attribute name="source" type="xs:string" use="required"/>
+        <xs:attribute name="text" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="RailComType">
+        <xs:attribute name="app" type="xs:unsignedByte" use="required"/>
+        <xs:attribute name="data" type="xs:hexBinary" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="DiscoveryType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="icon" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="SusiType">
+        <xs:attribute name="bank" type="xs:unsignedByte" use="required"/>
+        <xs:attribute name="index" type="xs:unsignedByte" use="required"/>
+        <xs:attribute name="value" type="xs:unsignedByte" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="ConfigType">
+        <xs:attribute name="domain" type="xs:string" use="required"/>
+        <xs:attribute name="data" type="xs:hexBinary" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="SyncType">
+        <xs:attribute name="type" type="SyncTypeEnum" use="required"/>
+        <xs:attribute name="value" type="xs:unsignedInt" use="optional"/>
+    </xs:complexType>
+
     <!-- Enumeration Definitions -->
     <xs:simpleType name="ProtocolEnum">
         <xs:restriction base="xs:string">
@@ -202,6 +239,17 @@
             <xs:enumeration value="QOS_ERROR_RATE"/>
             <xs:enumeration value="ODOMETER_VALUE"/>
             <xs:enumeration value="POSITION_CONFIDENCE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="SyncTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CAM_PULSE"/>
+            <xs:enumeration value="CYLINDER_CYCLE"/>
+            <xs:enumeration value="GEAR_CHANGE_UP"/>
+            <xs:enumeration value="GEAR_CHANGE_DOWN"/>
+            <xs:enumeration value="BRAKE_SQUEAL_START"/>
+            <xs:enumeration value="DOOR_MOVEMENT"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Adds XML examples for all events defined in the API.

- Creates XML files for 10 missing events.
- Updates `all_messages.xml` to include the new examples.
- Updates the XSD schema to support the new event types and attributes.
- Fixes validation errors in existing XML files.