### PR TITLE
Refactor: Rename CV-related events for clarity

### DIFF
--- a/examples/XmlCLI/XmlCLI.ino
+++ b/examples/XmlCLI/XmlCLI.ino
@@ -28,9 +28,9 @@ public:
     void onLocoExternalStateChange(const ModelRail::LocoHandle& loco, ModelRail::ExternalState state) override {}
     void onLocoRailComRawData(const ModelRail::LocoHandle& loco, uint8_t appId, const std::vector<uint8_t>& data) override {}
     void onNewLocoDiscovered(const ModelRail::LocoHandle& loco, const std::string& name, const std::string& icon) override {}
-    void onCvReadRequest(const ModelRail::LocoHandle& loco, int cvNumber) override {}
-    void onCvWriteRequest(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value) override {}
-    void onCvReadResult(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
+    void onCvRead(const ModelRail::LocoHandle& loco, int cvNumber) override {}
+    void onCvWrite(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value) override {}
+    void onCvReadDone(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
     void onSusiConfigRead(const ModelRail::LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {}
     void onConfigBlockLoad(const ModelRail::LocoHandle& loco, std::string domain, const std::vector<uint8_t>& data) override {}
     void onProgressUpdate(std::string operation, float percent) override {}

--- a/examples/debug_cli/debug_cli.ino
+++ b/examples/debug_cli/debug_cli.ino
@@ -62,7 +62,7 @@ public:
     void onLocoExternalStateChange(const ModelRail::LocoHandle& loco, ModelRail::ExternalState state) override {}
     void onLocoRailComRawData(const ModelRail::LocoHandle& loco, uint8_t appId, const std::vector<uint8_t>& data) override {}
     void onNewLocoDiscovered(const ModelRail::LocoHandle& loco, const std::string& name, const std::string& icon) override {}
-    void onCvReadResult(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
+    void onCvReadDone(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
     void onSusiConfigRead(const ModelRail::LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {}
     void onConfigBlockLoad(const ModelRail::LocoHandle& loco, std::string domain, const std::vector<uint8_t>& data) override {}
     void onProgressUpdate(std::string operation, float percent) override {}

--- a/examples/e2e_test/e2e_test.ino
+++ b/examples/e2e_test/e2e_test.ino
@@ -117,9 +117,9 @@ public:
     void onLocoExternalStateChanged(const ModelRail::LocoHandle& loco, ModelRail::ExternalState state) override {}
     void onLocoRailComRawData(const ModelRail::LocoHandle& loco, uint8_t appId, const std::vector<uint8_t>& data) override {}
     void onNewLocoDiscovered(const ModelRail::LocoHandle& loco, const std::string& name, const std::string& icon) override {}
-    void onCvReadRequest(const ModelRail::LocoHandle& loco, int cvNumber) override {}
-    void onCvWriteRequest(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value) override {}
-    void onCvReadResult(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
+    void onCvRead(const ModelRail::LocoHandle& loco, int cvNumber) override {}
+    void onCvWrite(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value) override {}
+    void onCvReadDone(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
     void onSusiConfigRead(const ModelRail::LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {}
     void onConfigBlockLoad(const ModelRail::LocoHandle& loco, std::string domain, const std::vector<uint8_t>& data) override {}
     void onProgressUpdate(std::string operation, float percent) override {}

--- a/examples/motor_cli/motor_cli.ino
+++ b/examples/motor_cli/motor_cli.ino
@@ -41,7 +41,7 @@ public:
     void onLocoExternalStateChange(const ModelRail::LocoHandle& loco, ModelRail::ExternalState state) override {}
     void onLocoRailComRawData(const ModelRail::LocoHandle& loco, uint8_t appId, const std::vector<uint8_t>& data) override {}
     void onNewLocoDiscovered(const ModelRail::LocoHandle& loco, const std::string& name, const std::string& icon) override {}
-    void onCvReadResult(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
+    void onCvReadDone(const ModelRail::LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {}
     void onSusiConfigRead(const ModelRail::LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {}
     void onConfigBlockLoad(const ModelRail::LocoHandle& loco, std::string domain, const std::vector<uint8_t>& data) override {}
     void onProgressUpdate(std::string operation, float percent) override {}

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -151,11 +151,11 @@ paths:
       responses:
         '202':
           description: "Event accepted."
-  /onCvWriteRequest:
+  /onCvWrite:
     post:
       summary: "CV Write Request"
       description: "Request to write a value to a configuration variable (CV)."
-      operationId: "onCvWriteRequest"
+      operationId: "onCvWrite"
       requestBody:
         required: true
         content:
@@ -182,11 +182,11 @@ paths:
       responses:
         '202':
           description: "Event accepted."
-  /onCvReadRequest:
+  /onCvRead:
     post:
       summary: "CV Read Request"
       description: "Request to read a value from a configuration variable (CV)."
-      operationId: "onCvReadRequest"
+      operationId: "onCvRead"
       requestBody:
         required: true
         content:
@@ -456,17 +456,17 @@ paths:
       responses:
         '202':
           description: "Event accepted."
-  /onCvReadResult:
+  /onCvReadDone:
     post:
-      summary: "CV Read Result"
+      summary: "CV Read Done"
       description: "Event for the result of a CV read operation."
-      operationId: "onCvReadResult"
+      operationId: "onCvReadDone"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CvReadResult'
+              $ref: '#/components/schemas/CvReadDone'
       responses:
         '202':
           description: "Event accepted."
@@ -633,7 +633,7 @@ components:
           type: string
           example: "System startup complete."
 
-    CvReadResult:
+    CvReadDone:
       type: object
       required: [loco, cvNumber, value, success]
       properties:

--- a/xDuinoRails_xTrainAPI.h
+++ b/xDuinoRails_xTrainAPI.h
@@ -277,7 +277,7 @@ namespace ModelRail {
          * @param loco The target locomotive.
          * @param cvNumber The Configuration Variable number to read.
          */
-        virtual void onCvReadRequest(const LocoHandle& loco, int cvNumber)                                               = 0;
+        virtual void onCvRead(const LocoHandle& loco, int cvNumber)                                               = 0;
 
         /**
          * @brief A request to write a CV to a decoder has been issued.
@@ -285,7 +285,7 @@ namespace ModelRail {
          * @param cvNumber The Configuration Variable number to write.
          * @param value The 8-bit value to write.
          */
-        virtual void onCvWriteRequest(const LocoHandle& loco, int cvNumber, uint8_t value)                                = 0;
+        virtual void onCvWrite(const LocoHandle& loco, int cvNumber, uint8_t value)                                = 0;
 
         /**
          * @brief Result of a CV read operation.
@@ -294,7 +294,7 @@ namespace ModelRail {
          * @param value The 8-bit value returned by the decoder.
          * @param success True if the read was successful (acknowledged).
          */
-        virtual void onCvReadResult(const LocoHandle& loco, int cvNumber, uint8_t value, bool success)                   = 0;
+        virtual void onCvReadDone(const LocoHandle& loco, int cvNumber, uint8_t value, bool success)                   = 0;
 
         /**
          * @brief Result of reading a SUSI configuration register.

--- a/xDuinoRails_xTrainAPI_utils.h
+++ b/xDuinoRails_xTrainAPI_utils.h
@@ -164,22 +164,22 @@ public:
     void onNewLocoDiscovered(const LocoHandle& loco, const std::string& name, const std::string& icon) override {
         _stream->println("onNewLocoDiscovered");
     }
-    void onCvReadRequest(const LocoHandle& loco, int cvNumber) override {
-        _stream->print("onCvReadRequest cab=");
+    void onCvRead(const LocoHandle& loco, int cvNumber) override {
+        _stream->print("onCvRead cab=");
         _stream->print(loco.address);
         _stream->print(" cv=");
         _stream->println(cvNumber);
     }
-    void onCvWriteRequest(const LocoHandle& loco, int cvNumber, uint8_t value) override {
-        _stream->print("onCvWriteRequest cab=");
+    void onCvWrite(const LocoHandle& loco, int cvNumber, uint8_t value) override {
+        _stream->print("onCvWrite cab=");
         _stream->print(loco.address);
         _stream->print(" cv=");
         _stream->print(cvNumber);
         _stream->print(" value=");
         _stream->println(value);
     }
-    void onCvReadResult(const LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {
-        _stream->println("onCvReadResult");
+    void onCvReadDone(const LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {
+        _stream->println("onCvReadDone");
     }
     void onSusiConfigRead(const LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {
         _stream->println("onSusiConfigRead");
@@ -333,14 +333,14 @@ public:
     void onNewLocoDiscovered(const LocoHandle& loco, const std::string& name, const std::string& icon) override {
         _stream->println("    <event type=\"onNewLocoDiscovered\"></event>");
     }
-    void onCvReadRequest(const LocoHandle& loco, int cvNumber) override {
-        _stream->println("    <event type=\"onCvReadRequest\"></event>");
+    void onCvRead(const LocoHandle& loco, int cvNumber) override {
+        _stream->println("    <event type=\"onCvRead\"></event>");
     }
-    void onCvWriteRequest(const LocoHandle& loco, int cvNumber, uint8_t value) override {
-        _stream->println("    <event type=\"onCvWriteRequest\"></event>");
+    void onCvWrite(const LocoHandle& loco, int cvNumber, uint8_t value) override {
+        _stream->println("    <event type=\"onCvWrite\"></event>");
     }
-    void onCvReadResult(const LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {
-        _stream->println("    <event type=\"onCvReadResult\"></event>");
+    void onCvReadDone(const LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {
+        _stream->println("    <event type=\"onCvReadDone\"></event>");
     }
     void onSusiConfigRead(const LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {
         _stream->println("    <event type=\"onSusiConfigRead\"></event>");

--- a/xml/all_messages.xml
+++ b/xml/all_messages.xml
@@ -138,19 +138,19 @@
     <!-- ===================================================================== -->
 
     <!-- Event: A CV read operation has completed. -->
-    <event type="onCvReadResult" timestamp="2024-07-29T10:08:30Z">
+    <event type="onCvReadDone" timestamp="2024-07-29T10:08:30Z">
         <loco address="5" protocol="DCC" />
         <cv cvNumber="5" value="200" success="true" />
     </event>
 
     <!-- Event: A request to read a CV from a decoder has been issued. -->
-    <event type="onCvReadRequest" timestamp="2024-07-29T10:08:00Z">
+    <event type="onCvRead" timestamp="2024-07-29T10:08:00Z">
         <loco address="3" protocol="DCC" />
         <cv cvNumber="5" />
     </event>
 
     <!-- Event: A request to write a CV to a decoder has been issued. -->
-    <event type="onCvWriteRequest" timestamp="2024-07-29T10:09:00Z">
+    <event type="onCvWrite" timestamp="2024-07-29T10:09:00Z">
         <loco address="3" protocol="DCC" />
         <cv cvNumber="5" value="128" />
     </event>

--- a/xml/onCvRead.xml
+++ b/xml/onCvRead.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onCvRead" timestamp="2024-07-29T10:08:00Z">
+        <loco address="3" protocol="DCC"/>
+        <cv cvNumber="5"/>
+    </event>
+</xTrainEvents>

--- a/xml/onCvReadDone.xml
+++ b/xml/onCvReadDone.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onCvReadDone" timestamp="2024-07-29T10:08:30Z">
+        <loco address="3" protocol="DCC"/>
+        <cv cvNumber="5" value="100" success="true"/>
+    </event>
+</xTrainEvents>

--- a/xml/onCvReadRequest.xml
+++ b/xml/onCvReadRequest.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xTrainEvents>
-    <event type="onCvReadRequest" timestamp="2024-07-29T10:08:00Z">
-        <loco address="3" protocol="DCC" />
-        <cv cvNumber="5" />
-    </event>
-</xTrainEvents>

--- a/xml/onCvReadResult.xml
+++ b/xml/onCvReadResult.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xTrainEvents>
-    <event type="onCvReadResult" timestamp="2024-07-29T10:08:30Z">
-        <loco address="5" protocol="DCC" />
-        <cv cvNumber="5" value="200" success="true" />
-    </event>
-</xTrainEvents>

--- a/xml/onCvWrite.xml
+++ b/xml/onCvWrite.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xTrainEvents>
+    <event type="onCvWrite" timestamp="2024-07-29T10:09:00Z">
+        <loco address="3" protocol="DCC"/>
+        <cv cvNumber="5" value="120"/>
+    </event>
+</xTrainEvents>

--- a/xml/onCvWriteRequest.xml
+++ b/xml/onCvWriteRequest.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xTrainEvents>
-    <event type="onCvWriteRequest" timestamp="2024-07-29T10:09:00Z">
-        <loco address="3" protocol="DCC" />
-        <cv cvNumber="5" value="128" />
-    </event>
-</xTrainEvents>


### PR DESCRIPTION
This commit refactors three CV-related event names to improve clarity and consistency across the API:

- `onCvReadRequest` has been renamed to `onCvRead`
- `onCvWriteRequest` has been renamed to `onCvWrite`
- `onCvReadResult` has been renamed to `onCvReadDone`

The changes have been applied consistently across the entire codebase, including the core API definition, utility classes, example sketches, XML schemas, and OpenAPI documentation.