### PR TITLE
feat: Add web-based API testing tool

### DIFF
--- a/webtool/index.html
+++ b/webtool/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>xTrain API Web Tool</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>xTrain API Web Tool</h1>
+    <div class="container">
+        <label for="target-url">Target URL Prefix:</label>
+        <input type="text" id="target-url" value="http://xtrain.local/xtrainV1">
+
+        <label for="message-type">Message Type:</label>
+        <select id="message-type"></select>
+
+        <label for="message-body">Message Body:</label>
+        <textarea id="message-body" rows="10"></textarea>
+
+        <button id="send-button">Send</button>
+
+        <div id="response-container">
+            <h2>Response</h2>
+            <pre id="response"></pre>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml/dist/js-yaml.min.js"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/webtool/main.js
+++ b/webtool/main.js
@@ -1,0 +1,131 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const targetUrlInput = document.getElementById('target-url');
+    const messageTypeSelect = document.getElementById('message-type');
+    const messageBodyTextarea = document.getElementById('message-body');
+    const sendButton = document.getElementById('send-button');
+    const responsePre = document.getElementById('response');
+
+    let openapiSpec = null;
+
+    // Function to fetch and parse the OpenAPI spec
+    const loadOpenApiSpec = async () => {
+        try {
+            const response = await fetch('../swagger/openapi.yaml');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const yamlText = await response.text();
+            openapiSpec = jsyaml.load(yamlText);
+            console.log('OpenAPI spec loaded successfully:', openapiSpec); // Debug log
+            populateMessageTypeDropdown();
+            updateMessageBody(); // Initial population
+        } catch (error) {
+            console.error('Error loading OpenAPI spec:', error);
+            // Make the error very visible for debugging
+            document.body.innerHTML = `<pre>FATAL ERROR: Could not load OpenAPI spec.\n${error.stack}</pre>`;
+        }
+    };
+
+    // Function to populate the message type dropdown
+    const populateMessageTypeDropdown = () => {
+        if (!openapiSpec || !openapiSpec.paths) {
+            return;
+        }
+
+        for (const path in openapiSpec.paths) {
+            const option = document.createElement('option');
+            const postOperation = openapiSpec.paths[path].post;
+            if (postOperation) {
+                const summary = postOperation.summary || path.substring(1); // Use summary or path name
+                option.value = path;
+                option.textContent = summary;
+                messageTypeSelect.appendChild(option);
+            }
+        }
+    };
+
+    // Function to update the message body with an example
+    const updateMessageBody = () => {
+        if (!openapiSpec) return;
+
+        const selectedPath = messageTypeSelect.value;
+        const pathSpec = openapiSpec.paths[selectedPath];
+
+        if (pathSpec && pathSpec.post && pathSpec.post.requestBody) {
+            const requestBody = pathSpec.post.requestBody;
+            const content = requestBody.content['application/json'];
+            if (content && content.examples) {
+                // Get the first example
+                const firstExampleKey = Object.keys(content.examples)[0];
+                const exampleValue = content.examples[firstExampleKey].value;
+                console.log('Updating message body with example:', exampleValue); // Debug log
+                messageBodyTextarea.value = JSON.stringify(exampleValue, null, 2);
+            } else if (content && content.schema) {
+                // If no example, create a placeholder from the schema (simplified)
+                 const exampleValue = createObjectFromSchema(content.schema);
+                 console.log('Updating message body with schema:', exampleValue); // Debug log
+                 messageBodyTextarea.value = JSON.stringify(exampleValue, null, 2);
+            }
+        } else {
+            console.log('No example or schema found for selected path:', selectedPath); // Debug log
+            messageBodyTextarea.value = '';
+        }
+    };
+
+    // Helper function to create a placeholder object from a schema
+    const createObjectFromSchema = (schemaRef) => {
+        const schemaName = schemaRef['$ref'].split('/').pop();
+        const schema = openapiSpec.components.schemas[schemaName];
+        const obj = {};
+        if (schema && schema.properties) {
+            for (const prop in schema.properties) {
+                const propSchemaRef = schema.properties[prop]['$ref'];
+                if(propSchemaRef) {
+                    obj[prop] = createObjectFromSchema(schema.properties[prop]);
+                } else {
+                    obj[prop] = schema.properties[prop].example || '';
+                }
+            }
+        }
+        return obj;
+    };
+
+
+    // Function to handle sending the message
+    const sendMessage = async () => {
+        const targetUrl = targetUrlInput.value;
+        const messageType = messageTypeSelect.value;
+        const messageBody = messageBodyTextarea.value;
+        const fullUrl = `${targetUrl}${messageType}`;
+
+        responsePre.textContent = 'Sending...';
+
+        try {
+            const response = await axios.post(fullUrl, JSON.parse(messageBody), {
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+            responsePre.textContent = JSON.stringify(response.data, null, 2);
+        } catch (error) {
+             if (error.response) {
+                // The request was made and the server responded with a status code
+                // that falls out of the range of 2xx
+                responsePre.textContent = `Error: ${error.message}\n\nStatus: ${error.response.status}\n\nResponse:\n${JSON.stringify(error.response.data, null, 2)}`;
+            } else if (error.request) {
+                // The request was made but no response was received
+                 responsePre.textContent = `Error: No response received from the server. Check the URL and network connection.\n\n${error.message}`;
+            } else {
+                // Something happened in setting up the request that triggered an Error
+                responsePre.textContent = `Error: ${error.message}`;
+            }
+        }
+    };
+
+    // Event Listeners
+    messageTypeSelect.addEventListener('change', updateMessageBody);
+    sendButton.addEventListener('click', sendMessage);
+
+    // Initial load
+    loadOpenApiSpec();
+});

--- a/webtool/style.css
+++ b/webtool/style.css
@@ -1,0 +1,60 @@
+body {
+    font-family: sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+}
+
+h1 {
+    text-align: center;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+}
+
+input[type="text"],
+select,
+textarea {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box; /* Important */
+}
+
+button {
+    background-color: #4CAF50;
+    color: white;
+    padding: 12px 20px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    width: 100%;
+}
+
+button:hover {
+    background-color: #45a049;
+}
+
+#response-container {
+    margin-top: 20px;
+}
+
+#response {
+    background-color: #eee;
+    padding: 15px;
+    border-radius: 4px;
+    white-space: pre-wrap; /* Allow wrapping */
+    word-wrap: break-word; /* Break long words */
+}


### PR DESCRIPTION
This commit introduces a new standalone web tool in the `webtool/` directory. The tool allows users to send any message type defined in the `/swagger/openapi.yaml` specification. It features a dropdown to select the message type, a field to enter the target URL prefix (defaulting to `http://xtrain.local/xtrainV1`), and a text area that is pre-filled with an example request body. The tool is implemented with plain HTML, CSS, and JavaScript, using the `axios` and `js-yaml` libraries loaded from a CDN.