### PR TITLE
feat: Deploy webtool to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,9 @@ jobs:
           mkdir -p public/swagger
           redocly build-docs swagger/openapi.yaml -o public/swagger/index.html
 
+      - name: Copy webtool to public directory
+        run: cp -r webtool public/
+
       - name: Create index page
         run: |
           echo '<!DOCTYPE html>
@@ -150,6 +153,7 @@ jobs:
             <ul>
               <li><a href="doxygen/index.html">Doxygen (C++ API)</a></li>
               <li><a href="swagger/index.html">Redocly (REST API)</a></li>
+              <li><a href="webtool/index.html">Web Tool</a></li>
             </ul>
           </body>
           </html>' > public/index.html

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Our API documentation is automatically generated and hosted on GitHub Pages.
 *   **Swagger (REST API):** The specification for our REST interface, including interactive endpoints, is available here:
     [Swagger UI](https://chatelao.github.io/xDuinoRails_xTrainAPI/swagger)
 
+*   **Web Tool:** A simple web application for interacting with the xTrainAPI is available here:
+    [Web Tool](https://chatelao.github.io/xDuinoRails_xTrainAPI/webtool)
+
 ## What is xTrainAPI?
 
 xTrainAPI is a unified interface that allows various digital model train systems to be controlled through a single, consistent API. This simplifies the development of control software by abstracting the complexity of individual protocols (such as DCC, Märklin Motorola, etc.).


### PR DESCRIPTION
- Added a step to the `build-and-deploy-docs` job in `build.yml` to copy the `webtool` directory to the `public` directory.
- Updated the main `index.html` in the `public` directory to include a link to the webtool.
- Updated `README.md` to include a link to the deployed webtool.