### PR TITLE
Fix: Correct OpenAPI spec path in web tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server.log

--- a/webtool/main.js
+++ b/webtool/main.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Function to fetch and parse the OpenAPI spec
     const loadOpenApiSpec = async () => {
         try {
-            const response = await fetch('../swagger/openapi.yaml');
+            const response = await fetch('/xDuinoRails_xTrainAPI/swagger/openapi.yaml');
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }


### PR DESCRIPTION
The web tool was failing to load the OpenAPI spec due to an incorrect relative path. This commit updates the path to be absolute from the root of the GitHub Pages site, which resolves the 404 error.

Additionally, a .gitignore file has been added to exclude server.log from version control.