### PR TITLE
Fix: webtool fails to load OpenAPI spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,9 @@ jobs:
           mkdir -p public/swagger
           redocly build-docs swagger/openapi.yaml -o public/swagger/index.html
 
+      - name: Copy swagger spec for webtool
+        run: cp swagger/openapi.yaml public/swagger/
+
       - name: Copy webtool to public directory
         run: cp -r webtool public/
 


### PR DESCRIPTION
The webtool was returning a 404 error on startup because it could not find the `openapi.yaml` file.

This commit modifies the `build-and-deploy-docs` job in the GitHub Actions workflow to copy the `swagger/openapi.yaml` file to the `public/swagger` directory. This ensures that the file is available to the webtool when deployed to GitHub Pages.