### PR TITLE
feat: ensure compliance with master header

### DIFF
--- a/json/xTrainEvent.schema.json
+++ b/json/xTrainEvent.schema.json
@@ -5,1369 +5,286 @@
   "$defs": {
     "AccessoryAnalogValue": {
       "type": "object",
-      "required": [
-        "address",
-        "value0to1"
-      ],
+      "required": [ "address", "value0to1" ],
       "properties": {
-        "address": {
-          "type": "integer",
-          "format": "uint16",
-          "example": 55
-        },
-        "value0to1": {
-          "type": "number",
-          "format": "float",
-          "example": 0.75
-        }
+        "address": { "type": "integer", "format": "uint16", "example": 55 },
+        "value0to1": { "type": "number", "format": "float", "example": 0.75 }
       }
     },
     "AccessoryError": {
       "type": "object",
-      "required": [
-        "address",
-        "errorId",
-        "errorMsg"
-      ],
+      "required": [ "address", "errorId", "errorMsg" ],
       "properties": {
-        "address": {
-          "type": "integer",
-          "format": "uint16",
-          "example": 201
-        },
-        "errorId": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 1
-        },
-        "errorMsg": {
-          "type": "string",
-          "example": "Overload detected"
-        }
+        "address": { "type": "integer", "format": "uint16", "example": 201 },
+        "errorId": { "type": "integer", "format": "uint8", "example": 1 },
+        "errorMsg": { "type": "string", "example": "Overload detected" }
       }
     },
     "onConfigBlockLoad": {
       "type": "object",
-      "required": [
-        "loco",
-        "domain",
-        "data"
-      ],
+      "required": [ "loco", "domain", "data" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "domain": {
-          "type": "string",
-          "example": "SoundProfile"
-        },
-        "data": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8"
-          },
-          "example": [
-            255,
-            254,
-            253,
-            252
-          ]
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "domain": { "type": "string", "example": "SoundProfile" },
+        "data": { "type": "array", "items": { "type": "integer", "format": "uint8" }, "example": [ 255, 254, 253, 252 ] }
       }
     },
     "ConsistLink": {
       "type": "object",
-      "required": [
-        "master",
-        "slave",
-        "type",
-        "inverted"
-      ],
+      "required": [ "master", "slave", "type", "inverted" ],
       "properties": {
-        "master": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "slave": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "ADVANCED_DCC",
-            "UNIVERSAL_HOST",
-            "MU_LOCONET"
-          ],
-          "example": "ADVANCED_DCC"
-        },
-        "inverted": {
-          "type": "boolean",
-          "example": false
-        }
+        "master": { "$ref": "#/$defs/LocoHandle" },
+        "slave": { "$ref": "#/$defs/LocoHandle" },
+        "type": { "type": "string", "enum": [ "ADVANCED_DCC", "UNIVERSAL_HOST", "MU_LOCONET" ], "example": "ADVANCED_DCC" },
+        "inverted": { "type": "boolean", "example": false }
       }
     },
     "ConsistUnlink": {
       "type": "object",
-      "required": [
-        "slave"
-      ],
+      "required": [ "slave" ],
       "properties": {
-        "slave": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        }
+        "slave": { "$ref": "#/$defs/LocoHandle" }
       }
     },
     "CvReadRequest": {
       "type": "object",
-      "required": [
-        "loco",
-        "cvNumber"
-      ],
+      "required": [ "loco", "cvNumber" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "cvNumber": {
-          "type": "integer",
-          "description": "The CV number to read from.",
-          "example": 8
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "cvNumber": { "type": "integer", "description": "The CV number to read from.", "example": 8 }
       }
     },
     "CvReadResult": {
       "type": "object",
-      "required": [
-        "loco",
-        "cvNumber",
-        "value",
-        "success"
-      ],
+      "required": [ "loco", "cvNumber", "value", "success" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "cvNumber": {
-          "type": "integer",
-          "example": 3
-        },
-        "value": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 20
-        },
-        "success": {
-          "type": "boolean",
-          "example": true
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "cvNumber": { "type": "integer", "example": 3 },
+        "value": { "type": "integer", "format": "uint8", "example": 20 },
+        "success": { "type": "boolean", "example": true }
       }
     },
     "CvWriteRequest": {
       "type": "object",
-      "required": [
-        "loco",
-        "cvNumber",
-        "value"
-      ],
+      "required": [ "loco", "cvNumber", "value" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "cvNumber": {
-          "type": "integer",
-          "description": "The CV number to write to.",
-          "example": 3
-        },
-        "value": {
-          "type": "integer",
-          "format": "uint8",
-          "description": "The 8-bit value to write.",
-          "example": 20
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "cvNumber": { "type": "integer", "description": "The CV number to write to.", "example": 3 },
+        "value": { "type": "integer", "format": "uint8", "description": "The 8-bit value to write.", "example": 20 }
       }
     },
     "FastClockUpdated": {
       "type": "object",
-      "required": [
-        "modelTimeUnix",
-        "factor"
-      ],
+      "required": [ "modelTimeUnix", "factor" ],
       "properties": {
-        "modelTimeUnix": {
-          "type": "integer",
-          "format": "int64",
-          "example": 1678886400
-        },
-        "factor": {
-          "type": "number",
-          "format": "float",
-          "example": 10.0
-        }
+        "modelTimeUnix": { "type": "integer", "format": "int64", "example": 1678886400 },
+        "factor": { "type": "number", "format": "float", "example": 10.0 }
       }
     },
     "HardwareNodeAttached": {
       "type": "object",
-      "required": [
-        "nodeUid",
-        "productName",
-        "booster"
-      ],
+      "required": [ "nodeUid", "productName", "booster" ],
       "properties": {
-        "nodeUid": {
-          "type": "string",
-          "example": "uuid-1234-abcd"
-        },
-        "productName": {
-          "type": "string",
-          "example": "xTrain Central Station"
-        },
-        "booster": {
-          "type": "boolean",
-          "example": true
-        }
+        "nodeUid": { "type": "string", "example": "uuid-1234-abcd" },
+        "productName": { "type": "string", "example": "xTrain Central Station" },
+        "booster": { "type": "boolean", "example": true }
       }
     },
     "HardwareNodeLost": {
       "type": "object",
-      "required": [
-        "nodeUid"
-      ],
+      "required": [ "nodeUid" ],
       "properties": {
-        "nodeUid": {
-          "type": "string",
-          "example": "uuid-1234-efgh"
-        }
+        "nodeUid": { "type": "string", "example": "uuid-1234-efgh" }
       }
     },
     "LocoDetectedOnBlock": {
       "type": "object",
-      "required": [
-        "sensorId",
-        "loco",
-        "orientation"
-      ],
+      "required": [ "sensorId", "loco", "orientation" ],
       "properties": {
-        "sensorId": {
-          "type": "integer",
-          "format": "uint32",
-          "example": 1001
-        },
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "orientation": {
-          "type": "string",
-          "enum": [
-            "NORMAL",
-            "INVERTED",
-            "UNKNOWN"
-          ],
-          "example": "NORMAL"
-        }
+        "sensorId": { "type": "integer", "format": "uint32", "example": 1001 },
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "orientation": { "type": "string", "enum": [ "NORMAL", "INVERTED", "UNKNOWN" ], "example": "NORMAL" }
       }
     },
     "LocoDispatchStateChanged": {
       "type": "object",
-      "required": [
-        "loco",
-        "isAcquired",
-        "ownerId"
-      ],
+      "required": [ "loco", "isAcquired", "ownerId" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "isAcquired": {
-          "type": "boolean",
-          "example": true
-        },
-        "ownerId": {
-          "type": "string",
-          "example": "throttle-5678"
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "isAcquired": { "type": "boolean", "example": true },
+        "ownerId": { "type": "string", "example": "throttle-5678" }
       }
     },
     "LocoExternalStateChanged": {
       "type": "object",
-      "required": [
-        "loco",
-        "state"
-      ],
+      "required": [ "loco", "state" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "FREE_RUN",
-            "STOPPED_BY_ABC_SIGNAL",
-            "STOPPED_BY_DC_BRAKE",
-            "STOPPED_BY_HLU",
-            "RESTRICTED_SPEED_HLU"
-          ],
-          "example": "FREE_RUN"
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "state": { "type": "string", "enum": [ "FREE_RUN", "STOPPED_BY_ABC_SIGNAL", "STOPPED_BY_DC_BRAKE", "STOPPED_BY_HLU", "RESTRICTED_SPEED_HLU" ], "example": "FREE_RUN" }
       }
     },
     "LocoFunctionAnalogValue": {
       "type": "object",
-      "required": [
-        "loco",
-        "fIndex",
-        "value"
-      ],
+      "required": [ "loco", "fIndex", "value" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "fIndex": {
-          "type": "integer",
-          "example": 5
-        },
-        "value": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 128
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "fIndex": { "type": "integer", "example": 5 },
+        "value": { "type": "integer", "format": "uint8", "example": 128 }
       }
     },
     "LocoFunctionChanged": {
       "type": "object",
-      "required": [
-        "loco",
-        "fIndex",
-        "isActive"
-      ],
+      "required": [ "loco", "fIndex", "isActive" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "fIndex": {
-          "type": "integer",
-          "description": "Function index (0 for light, 1 for F1, etc.).",
-          "example": 1
-        },
-        "isActive": {
-          "type": "boolean",
-          "example": true
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "fIndex": { "type": "integer", "description": "Function index (0 for light, 1 for F1, etc.).", "example": 1 },
+        "isActive": { "type": "boolean", "example": true }
       }
     },
     "LocoRailComRawData": {
       "type": "object",
-      "required": [
-        "loco",
-        "appId",
-        "data"
-      ],
+      "required": [ "loco", "appId", "data" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "appId": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 1
-        },
-        "data": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8"
-          },
-          "example": [
-            1,
-            2,
-            3,
-            4
-          ]
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "appId": { "type": "integer", "format": "uint8", "example": 1 },
+        "data": { "type": "array", "items": { "type": "integer", "format": "uint8" }, "example": [ 1, 2, 3, 4 ] }
       }
     },
     "LocoSpeedChanged": {
       "type": "object",
-      "required": [
-        "loco",
-        "speedPercent",
-        "direction",
-        "speedSteps"
-      ],
+      "required": [ "loco", "speedPercent", "direction", "speedSteps" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "speedPercent": {
-          "type": "number",
-          "format": "float",
-          "minimum": 0.0,
-          "maximum": 100.0,
-          "example": 75.5
-        },
-        "direction": {
-          "type": "string",
-          "enum": [
-            "REVERSE",
-            "FORWARD",
-            "UNKNOWN"
-          ],
-          "example": "FORWARD"
-        },
-        "speedSteps": {
-          "type": "integer",
-          "description": "The speed step mode (e.g., 14, 28, 128).",
-          "example": 128
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "speedPercent": { "type": "number", "format": "float", "minimum": 0, "maximum": 100, "example": 75.5 },
+        "direction": { "type": "string", "enum": [ "REVERSE", "FORWARD", "UNKNOWN" ], "example": "FORWARD" },
+        "speedSteps": { "type": "integer", "description": "The speed step mode (e.g., 14, 28, 128).", "example": 128 }
       }
     },
     "LocoSyncEvent": {
       "type": "object",
-      "required": [
-        "loco",
-        "type",
-        "value"
-      ],
+      "required": [ "loco", "type", "value" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "CAM_PULSE",
-            "CYLINDER_CYCLE",
-            "GEAR_CHANGE_UP",
-            "GEAR_CHANGE_DOWN",
-            "BRAKE_SQUEAL_START",
-            "DOOR_MOVEMENT"
-          ],
-          "example": "CAM_PULSE"
-        },
-        "value": {
-          "type": "integer",
-          "format": "uint32",
-          "example": 1
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "type": { "type": "string", "enum": [ "CAM_PULSE", "CYLINDER_CYCLE", "GEAR_CHANGE_UP", "GEAR_CHANGE_DOWN", "BRAKE_SQUEAL_START", "DOOR_MOVEMENT" ], "example": "CAM_PULSE" },
+        "value": { "type": "integer", "format": "uint32", "example": 1 }
       }
     },
     "LocoTelemetryData": {
       "type": "object",
-      "required": [
-        "loco",
-        "type",
-        "value"
-      ],
+      "required": [ "loco", "type", "value" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "SPEED_KMH",
-            "LOAD_PERCENT",
-            "VOLTAGE_TRACK",
-            "CURRENT_AMP",
-            "FUEL_LEVEL",
-            "TEMP_CELSIUS",
-            "QOS_ERROR_RATE",
-            "ODOMETER_VALUE",
-            "POSITION_CONFIDENCE"
-          ],
-          "example": "SPEED_KMH"
-        },
-        "value": {
-          "type": "number",
-          "format": "float",
-          "example": 88.5
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "type": { "type": "string", "enum": [ "SPEED_KMH", "LOAD_PERCENT", "VOLTAGE_TRACK", "CURRENT_AMP", "FUEL_LEVEL", "TEMP_CELSIUS", "QOS_ERROR_RATE", "ODOMETER_VALUE", "POSITION_CONFIDENCE" ], "example": "SPEED_KMH" },
+        "value": { "type": "number", "format": "float", "example": 88.5 }
       }
     },
     "NewLocoDiscovered": {
       "type": "object",
-      "required": [
-        "loco",
-        "name",
-        "icon"
-      ],
+      "required": [ "loco", "name", "icon" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "name": {
-          "type": "string",
-          "example": "BR 18.5"
-        },
-        "icon": {
-          "type": "string",
-          "example": "br185.png"
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "name": { "type": "string", "example": "BR 18.5" },
+        "icon": { "type": "string", "example": "br185.png" }
       }
     },
     "ProgressUpdate": {
       "type": "object",
-      "required": [
-        "operation",
-        "percent"
-      ],
+      "required": [ "operation", "percent" ],
       "properties": {
-        "operation": {
-          "type": "string",
-          "example": "FirmwareUpdate"
-        },
-        "percent": {
-          "type": "number",
-          "format": "float",
-          "example": 50.5
-        }
+        "operation": { "type": "string", "example": "FirmwareUpdate" },
+        "percent": { "type": "number", "format": "float", "example": 50.5 }
       }
     },
     "SensorStateChanged": {
       "type": "object",
-      "required": [
-        "sensorId",
-        "isActive"
-      ],
+      "required": [ "sensorId", "isActive" ],
       "properties": {
-        "sensorId": {
-          "type": "integer",
-          "format": "uint32",
-          "example": 1002
-        },
-        "isActive": {
-          "type": "boolean",
-          "description": "True for occupied/active, False for free.",
-          "example": true
-        }
+        "sensorId": { "type": "integer", "format": "uint32", "example": 1002 },
+        "isActive": { "type": "boolean", "description": "True for occupied/active, False for free.", "example": true }
       }
     },
     "SignalAspectChanged": {
       "type": "object",
-      "required": [
-        "address",
-        "aspectId",
-        "isFeedback"
-      ],
+      "required": [ "address", "aspectId", "isFeedback" ],
       "properties": {
-        "address": {
-          "type": "integer",
-          "format": "uint16",
-          "example": 301
-        },
-        "aspectId": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 2
-        },
-        "isFeedback": {
-          "type": "boolean",
-          "example": false
-        }
+        "address": { "type": "integer", "format": "uint16", "example": 301 },
+        "aspectId": { "type": "integer", "format": "uint8", "example": 2 },
+        "isFeedback": { "type": "boolean", "example": false }
       }
     },
     "SusiConfigRead": {
       "type": "object",
-      "required": [
-        "loco",
-        "bankIndex",
-        "susiIndex",
-        "value"
-      ],
+      "required": [ "loco", "bankIndex", "susiIndex", "value" ],
       "properties": {
-        "loco": {
-          "type": "object",
-          "description": "Unique identifier for a locomotive.",
-          "required": [
-            "address",
-            "protocol"
-          ],
-          "properties": {
-            "address": {
-              "type": "integer",
-              "format": "uint16",
-              "description": "Primary address of the locomotive.",
-              "example": 101
-            },
-            "protocol": {
-              "type": "string",
-              "enum": [
-                "DCC",
-                "MM_I",
-                "MM_II",
-                "MFX",
-                "SELECTRIX",
-                "SX2",
-                "LOCONET",
-                "BIDIB",
-                "XPRESSNET",
-                "CAN_GENERIC"
-              ],
-              "example": "DCC"
-            },
-            "mfxUid": {
-              "type": "integer",
-              "format": "uint32",
-              "description": "Unique mfx ID, if applicable.",
-              "example": 16385
-            }
-          }
-        },
-        "bankIndex": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 1
-        },
-        "susiIndex": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 5
-        },
-        "value": {
-          "type": "integer",
-          "format": "uint8",
-          "example": 255
-        }
+        "loco": { "$ref": "#/$defs/LocoHandle" },
+        "bankIndex": { "type": "integer", "format": "uint8", "example": 1 },
+        "susiIndex": { "type": "integer", "format": "uint8", "example": 5 },
+        "value": { "type": "integer", "format": "uint8", "example": 255 }
       }
     },
     "SystemMessage": {
       "type": "object",
-      "required": [
-        "source",
-        "message"
-      ],
+      "required": [ "source", "message" ],
       "properties": {
-        "source": {
-          "type": "string",
-          "example": "CommandStation"
-        },
-        "message": {
-          "type": "string",
-          "example": "System startup complete."
-        }
+        "source": { "type": "string", "example": "CommandStation" },
+        "message": { "type": "string", "example": "System startup complete." }
       }
     },
     "TrackPowerChanged": {
       "type": "object",
-      "required": [
-        "state"
-      ],
+      "required": [ "state" ],
       "properties": {
-        "state": {
-          "type": "string",
-          "enum": [
-            "OFF",
-            "ON",
-            "EMERGENCY_STOP",
-            "SHORT_CIRCUIT"
-          ],
-          "example": "ON"
-        }
+        "state": { "type": "string", "enum": [ "OFF", "ON", "EMERGENCY_STOP", "SHORT_CIRCUIT" ], "example": "ON" }
       }
     },
     "TurnoutChanged": {
       "type": "object",
-      "required": [
-        "address",
-        "isThrown",
-        "isFeedback"
-      ],
+      "required": [ "address", "isThrown", "isFeedback" ],
       "properties": {
-        "address": {
-          "type": "integer",
-          "format": "uint16",
-          "example": 25
-        },
-        "isThrown": {
-          "type": "boolean",
-          "description": "True for diverging/thrown, False for straight.",
-          "example": true
-        },
-        "isFeedback": {
-          "type": "boolean",
-          "description": "True if this is a confirmation from hardware.",
-          "example": false
-        }
+        "address": { "type": "integer", "format": "uint16", "example": 25 },
+        "isThrown": { "type": "boolean", "description": "True for diverging/thrown, False for straight.", "example": true },
+        "isFeedback": { "type": "boolean", "description": "True if this is a confirmation from hardware.", "example": false }
       }
+    },
+    "LocoHandle": {
+        "type": "object",
+        "description": "Unique identifier for a locomotive.",
+        "required": [ "address", "protocol" ],
+        "properties": {
+            "address": { "type": "integer", "format": "uint16", "description": "Primary address of the locomotive.", "example": 101 },
+            "protocol": { "type": "string", "enum": [ "DCC", "MM_I", "MM_II", "MFX", "SELECTRIX", "SX2", "LOCONET", "BIDIB", "XPRESSNET", "CAN_GENERIC" ], "example": "DCC" },
+            "mfxUid": { "type": "integer", "format": "uint32", "description": "Unique mfx ID, if applicable.", "example": 16385 }
+        }
     }
   },
   "oneOf": [
-    {
-      "$ref": "#/$defs/AccessoryAnalogValue"
-    },
-    {
-      "$ref": "#/$defs/AccessoryError"
-    },
-    {
-      "$ref": "#/$defs/onConfigBlockLoad"
-    },
-    {
-      "$ref": "#/$defs/ConsistLink"
-    },
-    {
-      "$ref": "#/$defs/ConsistUnlink"
-    },
-    {
-      "$ref": "#/$defs/CvReadRequest"
-    },
-    {
-      "$ref": "#/$defs/CvReadResult"
-    },
-    {
-      "$ref": "#/$defs/CvWriteRequest"
-    },
-    {
-      "$ref": "#/$defs/FastClockUpdated"
-    },
-    {
-      "$ref": "#/$defs/HardwareNodeAttached"
-    },
-    {
-      "$ref": "#/$defs/HardwareNodeLost"
-    },
-    {
-      "$ref": "#/$defs/LocoDetectedOnBlock"
-    },
-    {
-      "$ref": "#/$defs/LocoDispatchStateChanged"
-    },
-    {
-      "$ref": "#/$defs/LocoExternalStateChanged"
-    },
-    {
-      "$ref": "#/$defs/LocoFunctionAnalogValue"
-    },
-    {
-      "$ref": "#/$defs/LocoFunctionChanged"
-    },
-    {
-      "$ref": "#/$defs/LocoRailComRawData"
-    },
-    {
-      "$ref": "#/$defs/LocoSpeedChanged"
-    },
-    {
-      "$ref": "#/$defs/LocoSyncEvent"
-    },
-    {
-      "$ref": "#/$defs/LocoTelemetryData"
-    },
-    {
-      "$ref": "#/$defs/NewLocoDiscovered"
-    },
-    {
-      "$ref": "#/$defs/ProgressUpdate"
-    },
-    {
-      "$ref": "#/$defs/SensorStateChanged"
-    },
-    {
-      "$ref": "#/$defs/SignalAspectChanged"
-    },
-    {
-      "$ref": "#/$defs/SusiConfigRead"
-    },
-    {
-      "$ref": "#/$defs/SystemMessage"
-    },
-    {
-      "$ref": "#/$defs/TrackPowerChanged"
-    },
-    {
-      "$ref": "#/$defs/TurnoutChanged"
-    }
+    { "$ref": "#/$defs/AccessoryAnalogValue" },
+    { "$ref": "#/$defs/AccessoryError" },
+    { "$ref": "#/$defs/onConfigBlockLoad" },
+    { "$ref": "#/$defs/ConsistLink" },
+    { "$ref": "#/$defs/ConsistUnlink" },
+    { "$ref": "#/$defs/CvReadRequest" },
+    { "$ref": "#/$defs/CvReadResult" },
+    { "$ref": "#/$defs/CvWriteRequest" },
+    { "$ref": "#/$defs/FastClockUpdated" },
+    { "$ref": "#/$defs/HardwareNodeAttached" },
+    { "$ref": "#/$defs/HardwareNodeLost" },
+    { "$ref": "#/$defs/LocoDetectedOnBlock" },
+    { "$ref": "#/$defs/LocoDispatchStateChanged" },
+    { "$ref": "#/$defs/LocoExternalStateChanged" },
+    { "$ref": "#/$defs/LocoFunctionAnalogValue" },
+    { "$ref": "#/$defs/LocoFunctionChanged" },
+    { "$ref": "#/$defs/LocoRailComRawData" },
+    { "$ref": "#/$defs/LocoSpeedChanged" },
+    { "$ref": "#/$defs/LocoSyncEvent" },
+    { "$ref": "#/$defs/LocoTelemetryData" },
+    { "$ref": "#/$defs/NewLocoDiscovered" },
+    { "$ref": "#/$defs/ProgressUpdate" },
+    { "$ref": "#/$defs/SensorStateChanged" },
+    { "$ref": "#/$defs/SignalAspectChanged" },
+    { "$ref": "#/$defs/SusiConfigRead" },
+    { "$ref": "#/$defs/SystemMessage" },
+    { "$ref": "#/$defs/TrackPowerChanged" },
+    { "$ref": "#/$defs/TurnoutChanged" }
   ]
 }

--- a/xDuinoRails_xTrainAPI_utils.h
+++ b/xDuinoRails_xTrainAPI_utils.h
@@ -242,7 +242,9 @@ public:
         _stream->println("    <event type=\"onLocoSpeedChange\">");
         _stream->print("        <loco address=\"");
         _stream->print(loco.address);
-        _stream->print("\" protocol=\"DCC\" mfxUid=\"");
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->print("\" mfxUid=\"");
         _stream->print(loco.mfxUid);
         _stream->println("\" />");
         _stream->print("        <speed speedPercent=\"");
@@ -259,7 +261,9 @@ public:
         _stream->println("    <event type=\"onLocoFunctionChange\">");
         _stream->print("        <loco address=\"");
         _stream->print(loco.address);
-        _stream->println("\" protocol=\"DCC\" />");
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
         _stream->print("        <function fIndex=\"");
         _stream->print(fIndex);
         _stream->print("\" isActive=\"");
@@ -271,7 +275,9 @@ public:
         _stream->println("    <event type=\"onLocoFunctionAnalogChange\">");
         _stream->print("        <loco address=\"");
         _stream->print(loco.address);
-        _stream->println("\" protocol=\"DCC\" />");
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
         _stream->print("        <function fIndex=\"");
         _stream->print(fIndex);
         _stream->print("\" value=\"");
@@ -280,82 +286,332 @@ public:
         _stream->println("    </event>");
     }
     void onLocoDispatchStateChange(const LocoHandle& loco, bool isAcquired, std::string ownerId) override {
-        _stream->println("    <event type=\"onLocoDispatchStateChange\"></event>");
+        _stream->println("    <event type=\"onLocoDispatchStateChange\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <dispatch isAcquired=\"");
+        _stream->print(isAcquired ? "true" : "false");
+        _stream->print("\" ownerId=\"");
+        escapeXml(ownerId);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onConsistLink(const LocoHandle& master, const LocoHandle& slave, ConsistType type, bool inverted) override {
-        _stream->println("    <event type=\"onConsistLink\"></event>");
+        _stream->println("    <event type=\"onConsistLink\">");
+        _stream->print("        <master address=\"");
+        _stream->print(master.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(master.protocol);
+        _stream->println("\" />");
+        _stream->print("        <slave address=\"");
+        _stream->print(slave.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(slave.protocol);
+        _stream->println("\" />");
+        _stream->print("        <consist type=\"");
+        switch (type) {
+            case ConsistType::ADVANCED_DCC: _stream->print("ADVANCED_DCC"); break;
+            case ConsistType::UNIVERSAL_HOST: _stream->print("UNIVERSAL_HOST"); break;
+            case ConsistType::MU_LOCONET: _stream->print("MU_LOCONET"); break;
+        }
+        _stream->print("\" inverted=\"");
+        _stream->print(inverted ? "true" : "false");
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onConsistUnlink(const LocoHandle& slave) override {
-        _stream->println("    <event type=\"onConsistUnlink\"></event>");
+        _stream->println("    <event type=\"onConsistUnlink\">");
+        _stream->print("        <slave address=\"");
+        _stream->print(slave.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(slave.protocol);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onTurnoutChange(uint16_t address, bool isThrown, bool isFeedback) override {
-        _stream->println("    <event type=\"onTurnoutChange\"></event>");
+        _stream->println("    <event type=\"onTurnoutChange\">");
+        _stream->print("        <turnout address=\"");
+        _stream->print(address);
+        _stream->print("\" isThrown=\"");
+        _stream->print(isThrown ? "true" : "false");
+        _stream->print("\" isFeedback=\"");
+        _stream->print(isFeedback ? "true" : "false");
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onSignalAspectChange(uint16_t address, uint8_t aspectId, bool isFeedback) override {
-        _stream->println("    <event type=\"onSignalAspectChange\"></event>");
+        _stream->println("    <event type=\"onSignalAspectChange\">");
+        _stream->print("        <signal address=\"");
+        _stream->print(address);
+        _stream->print("\" aspectId=\"");
+        _stream->print(aspectId);
+        _stream->print("\" isFeedback=\"");
+        _stream->print(isFeedback ? "true" : "false");
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onAccessoryAnalogValue(uint16_t address, float value0to1) override {
-        _stream->println("    <event type=\"onAccessoryAnalogValue\"></event>");
+        _stream->println("    <event type=\"onAccessoryAnalogValue\">");
+        _stream->print("        <accessory address=\"");
+        _stream->print(address);
+        _stream->print("\" value0to1=\"");
+        _stream->print(value0to1);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onAccessoryError(uint16_t address, uint8_t errorId, std::string errorMsg) override {
-        _stream->println("    <event type=\"onAccessoryError\"></event>");
+        _stream->println("    <event type=\"onAccessoryError\">");
+        _stream->print("        <accessory address=\"");
+        _stream->print(address);
+        _stream->print("\" errorId=\"");
+        _stream->print(errorId);
+        _stream->print("\" errorMsg=\"");
+        escapeXml(errorMsg);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onSensorStateChange(uint32_t sensorId, bool isActive) override {
-        _stream->println("    <event type=\"onSensorStateChange\"></event>");
+        _stream->println("    <event type=\"onSensorStateChange\">");
+        _stream->print("        <sensor sensorId=\"");
+        _stream->print(sensorId);
+        _stream->print("\" isActive=\"");
+        _stream->print(isActive ? "true" : "false");
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onTrackPowerChange(PowerState state) override {
-        _stream->println("    <event type=\"onTrackPowerChange\"></event>");
+        _stream->println("    <event type=\"onTrackPowerChange\">");
+        _stream->print("        <power state=\"");
+        switch (state) {
+            case PowerState::OFF: _stream->print("OFF"); break;
+            case PowerState::ON: _stream->print("ON"); break;
+            case PowerState::EMERGENCY_STOP: _stream->print("EMERGENCY_STOP"); break;
+            case PowerState::SHORT_CIRCUIT: _stream->print("SHORT_CIRCUIT"); break;
+        }
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onFastClockUpdated(int64_t modelTimeUnix, float factor) override {
-        _stream->println("    <event type=\"onFastClockUpdated\"></event>");
+        _stream->println("    <event type=\"onFastClockUpdated\">");
+        _stream->print("        <clock modelTimeUnix=\"");
+        _stream->print(modelTimeUnix);
+        _stream->print("\" factor=\"");
+        _stream->print(factor);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onHardwareNodeAttached(std::string nodeUid, std::string productName, bool booster) override {
-        _stream->println("    <event type=\"onHardwareNodeAttached\"></event>");
+        _stream->println("    <event type=\"onHardwareNodeAttached\">");
+        _stream->print("        <node nodeUid=\"");
+        escapeXml(nodeUid);
+        _stream->print("\" productName=\"");
+        escapeXml(productName);
+        _stream->print("\" booster=\"");
+        _stream->print(booster ? "true" : "false");
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onHardwareNodeLost(std::string nodeUid) override {
-        _stream->println("    <event type=\"onHardwareNodeLost\"></event>");
+        _stream->println("    <event type=\"onHardwareNodeLost\">");
+        _stream->print("        <node nodeUid=\"");
+        escapeXml(nodeUid);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onSystemMessage(std::string source, std::string message) override {
-        _stream->println("    <event type=\"onSystemMessage\"></event>");
+        _stream->println("    <event type=\"onSystemMessage\">");
+        _stream->print("        <message source=\"");
+        escapeXml(source);
+        _stream->print("\" message=\"");
+        escapeXml(message);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onLocoDetectedOnBlock(uint32_t sensorId, const LocoHandle& loco, DecoderOrientation orientation) override {
-        _stream->println("    <event type=\"onLocoDetectedOnBlock\"></event>");
+        _stream->println("    <event type=\"onLocoDetectedOnBlock\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <detection sensorId=\"");
+        _stream->print(sensorId);
+        _stream->print("\" orientation=\"");
+        switch (orientation) {
+            case DecoderOrientation::NORMAL: _stream->print("NORMAL"); break;
+            case DecoderOrientation::INVERTED: _stream->print("INVERTED"); break;
+            case DecoderOrientation::UNKNOWN: _stream->print("UNKNOWN"); break;
+        }
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onLocoTelemetryData(const LocoHandle& loco, TelemetryType type, float value) override {
-        _stream->println("    <event type=\"onLocoTelemetryData\"></event>");
+        _stream->println("    <event type=\"onLocoTelemetryData\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <telemetry type=\"");
+        switch (type) {
+            case TelemetryType::SPEED_KMH: _stream->print("SPEED_KMH"); break;
+            case TelemetryType::LOAD_PERCENT: _stream->print("LOAD_PERCENT"); break;
+            case TelemetryType::VOLTAGE_TRACK: _stream->print("VOLTAGE_TRACK"); break;
+            case TelemetryType::CURRENT_AMP: _stream->print("CURRENT_AMP"); break;
+            case TelemetryType::FUEL_LEVEL: _stream->print("FUEL_LEVEL"); break;
+            case TelemetryType::TEMP_CELSIUS: _stream->print("TEMP_CELSIUS"); break;
+            case TelemetryType::QOS_ERROR_RATE: _stream->print("QOS_ERROR_RATE"); break;
+            case TelemetryType::ODOMETER_VALUE: _stream->print("ODOMETER_VALUE"); break;
+            case TelemetryType::POSITION_CONFIDENCE: _stream->print("POSITION_CONFIDENCE"); break;
+        }
+        _stream->print("\" value=\"");
+        _stream->print(value);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onLocoExternalStateChange(const LocoHandle& loco, ExternalState state) override {
-        _stream->println("    <event type=\"onLocoExternalStateChange\"></event>");
+        _stream->println("    <event type=\"onLocoExternalStateChange\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <externalState state=\"");
+        switch (state) {
+            case ExternalState::FREE_RUN: _stream->print("FREE_RUN"); break;
+            case ExternalState::STOPPED_BY_ABC_SIGNAL: _stream->print("STOPPED_BY_ABC_SIGNAL"); break;
+            case ExternalState::STOPPED_BY_DC_BRAKE: _stream->print("STOPPED_BY_DC_BRAKE"); break;
+            case ExternalState::STOPPED_BY_HLU: _stream->print("STOPPED_BY_HLU"); break;
+            case ExternalState::RESTRICTED_SPEED_HLU: _stream->print("RESTRICTED_SPEED_HLU"); break;
+        }
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onLocoRailComRawData(const LocoHandle& loco, uint8_t appId, const std::vector<uint8_t>& data) override {
-        _stream->println("    <event type=\"onLocoRailComRawData\"></event>");
+        _stream->println("    <event type=\"onLocoRailComRawData\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <railcom appId=\"");
+        _stream->print(appId);
+        _stream->print("\" data=\"");
+        for (uint8_t byte : data) {
+            if (byte < 16) _stream->print('0');
+            _stream->print(byte, HEX);
+        }
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onNewLocoDiscovered(const LocoHandle& loco, const std::string& name, const std::string& icon) override {
-        _stream->println("    <event type=\"onNewLocoDiscovered\"></event>");
+        _stream->println("    <event type=\"onNewLocoDiscovered\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <discovery name=\"");
+        escapeXml(name);
+        _stream->print("\" icon=\"");
+        escapeXml(icon);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onCvRead(const LocoHandle& loco, int cvNumber) override {
-        _stream->println("    <event type=\"onCvRead\"></event>");
+        _stream->println("    <event type=\"onCvRead\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <cv cvNumber=\"");
+        _stream->print(cvNumber);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onCvWrite(const LocoHandle& loco, int cvNumber, uint8_t value) override {
-        _stream->println("    <event type=\"onCvWrite\"></event>");
+        _stream->println("    <event type=\"onCvWrite\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <cv cvNumber=\"");
+        _stream->print(cvNumber);
+        _stream->print("\" value=\"");
+        _stream->print(value);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onCvReadDone(const LocoHandle& loco, int cvNumber, uint8_t value, bool success) override {
-        _stream->println("    <event type=\"onCvReadDone\"></event>");
+        _stream->println("    <event type=\"onCvReadDone\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <cv cvNumber=\"");
+        _stream->print(cvNumber);
+        _stream->print("\" value=\"");
+        _stream->print(value);
+        _stream->print("\" success=\"");
+        _stream->print(success ? "true" : "false");
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onSusiConfigRead(const LocoHandle& loco, uint8_t bankIndex, uint8_t susiIndex, uint8_t value) override {
-        _stream->println("    <event type=\"onSusiConfigRead\"></event>");
+        _stream->println("    <event type=\"onSusiConfigRead\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <susi bank=\"");
+        _stream->print(bankIndex);
+        _stream->print("\" index=\"");
+        _stream->print(susiIndex);
+        _stream->print("\" value=\"");
+        _stream->print(value);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onConfigBlockLoad(const LocoHandle& loco, std::string domain, const std::vector<uint8_t>& data) override {
-        _stream->println("    <event type=\"onConfigBlockLoad\"></event>");
+        _stream->println("    <event type=\"onConfigBlockLoad\">");
+        _stream->print("        <loco address=\"");
+        _stream->print(loco.address);
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->println("\" />");
+        _stream->print("        <config domain=\"");
+        escapeXml(domain);
+        _stream->print("\" data=\"");
+        for (uint8_t byte : data) {
+            if (byte < 16) _stream->print('0');
+            _stream->print(byte, HEX);
+        }
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onProgressUpdate(std::string operation, float percent) override {
-        _stream->println("    <event type=\"onProgressUpdate\"></event>");
+        _stream->println("    <event type=\"onProgressUpdate\">");
+        _stream->print("        <progress operation=\"");
+        escapeXml(operation);
+        _stream->print("\" percent=\"");
+        _stream->print(percent);
+        _stream->println("\" />");
+        _stream->println("    </event>");
     }
     void onLocoEventSync(const LocoHandle& loco, SyncType type, uint32_t value) override {
         _stream->println("    <event type=\"onLocoEventSync\">");
         _stream->print("        <loco address=\"");
         _stream->print(loco.address);
-        _stream->print("\" protocol=\"DCC\" mfxUid=\"");
+        _stream->print("\" protocol=\"");
+        printProtocol(loco.protocol);
+        _stream->print("\" mfxUid=\"");
         _stream->print(loco.mfxUid);
         _stream->println("\" />");
         _stream->print("        <sync type=\"");
@@ -375,6 +631,34 @@ public:
 
 private:
     Stream* _stream;
+
+    void printProtocol(Protocol protocol) {
+        switch (protocol) {
+            case Protocol::DCC: _stream->print("DCC"); break;
+            case Protocol::MM_I: _stream->print("MM_I"); break;
+            case Protocol::MM_II: _stream->print("MM_II"); break;
+            case Protocol::MFX: _stream->print("MFX"); break;
+            case Protocol::SELECTRIX: _stream->print("SELECTRIX"); break;
+            case Protocol::SX2: _stream->print("SX2"); break;
+            case Protocol::LOCONET: _stream->print("LOCONET"); break;
+            case Protocol::BIDIB: _stream->print("BIDIB"); break;
+            case Protocol::XPRESSNET: _stream->print("XPRESSNET"); break;
+            case Protocol::CAN_GENERIC: _stream->print("CAN_GENERIC"); break;
+        }
+    }
+
+    void escapeXml(const std::string& str) {
+        for (char c : str) {
+            switch (c) {
+                case '&': _stream->print("&amp;"); break;
+                case '<': _stream->print("&lt;"); break;
+                case '>': _stream->print("&gt;"); break;
+                case '"': _stream->print("&quot;"); break;
+                case '\'': _stream->print("&apos;"); break;
+                default: _stream->print(c);
+            }
+        }
+    }
 };
 
 class XmlParser {

--- a/xml/all_messages.xml
+++ b/xml/all_messages.xml
@@ -95,7 +95,7 @@
 
     <!-- Event: A generic system message or log entry. -->
     <event type="onSystemMessage" timestamp="2024-07-29T10:05:00Z">
-        <message source="PowerManager" text="Emergency stop triggered by user." />
+        <message source="PowerManager" message="Emergency stop triggered by user." />
     </event>
 
     <!-- ===================================================================== -->
@@ -104,9 +104,8 @@
 
     <!-- Event: A locomotive has been detected on a specific track block. -->
     <event type="onLocoDetectedOnBlock" timestamp="2024-07-29T10:06:15Z">
-        <sensor sensorId="501" />
         <loco address="3" protocol="DCC" />
-        <detection orientation="NORMAL" />
+        <detection sensorId="501" orientation="NORMAL" />
     </event>
 
     <!-- Event: Telemetry data has been received from a locomotive. -->

--- a/xml/onLocoDetectedOnBlock.xml
+++ b/xml/onLocoDetectedOnBlock.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xTrainEvents>
     <event type="onLocoDetectedOnBlock" timestamp="2024-07-29T10:06:15Z">
-        <sensor sensorId="501" />
         <loco address="3" protocol="DCC" />
-        <detection orientation="NORMAL" />
+        <detection sensorId="501" orientation="NORMAL" />
     </event>
 </xTrainEvents>

--- a/xml/onSystemMessage.xml
+++ b/xml/onSystemMessage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xTrainEvents>
     <event type="onSystemMessage" timestamp="2024-07-29T10:05:00Z">
-        <message source="PowerManager" text="Emergency stop triggered by user." />
+        <message source="PowerManager" message="Emergency stop triggered by user." />
     </event>
 </xTrainEvents>

--- a/xml/xTrainEvents.xsd
+++ b/xml/xTrainEvents.xsd
@@ -44,10 +44,10 @@
         </xs:sequence>
         <xs:attribute name="type" type="xs:string" use="required">
             <xs:annotation>
-                <xs:documentation>onLocoSpeedChanged</xs:documentation>
+                <xs:documentation>The name of the event, e.g., 'onLocoSpeedChange'.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="timestamp" type="xs:dateTime" use="required">
+        <xs:attribute name="timestamp" type="xs:dateTime" use="optional">
             <xs:annotation>
                 <xs:documentation>2023-03-15T12:00:00Z</xs:documentation>
             </xs:annotation>
@@ -231,6 +231,7 @@
     </xs:complexType>
 
     <xs:complexType name="DetectionType">
+        <xs:attribute name="sensorId" type="xs:positiveInteger" use="required"/>
         <xs:attribute name="orientation" type="DecoderOrientationEnum" use="required"/>
     </xs:complexType>
 
@@ -284,7 +285,7 @@
                 <xs:documentation>CommandStation</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="text" type="xs:string" use="required">
+        <xs:attribute name="message" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>System startup complete.</xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
This commit ensures that all derivative files are compliant with the master header `xDuinoRails_xTrainAPI.h`.

The `XmlPrinter` class in `xDuinoRails_xTrainAPI_utils.h` has been fully implemented to correctly serialize all event types. Helper functions have been added to handle XML escaping and protocol printing.

The `xml/xTrainEvents.xsd`, `swagger/openapi.yaml`, and `json/xTrainEvent.schema.json` files have been updated to be consistent with the master header and with each other.

All example XML files in the `xml/` directory have been updated to be compliant with the new schema.