### PR TITLE
feat(api): Add self-inspection capability to xTrainAPI

### DIFF
--- a/xDuinoRails_xTrainAPI_utils.h
+++ b/xDuinoRails_xTrainAPI_utils.h
@@ -14,6 +14,8 @@ class CmdLinePrinter : public IUnifiedModelTrainListener {
 public:
     CmdLinePrinter(Stream& stream) : _stream(&stream) {}
 
+    uint64_t getImplementedApi() const override { return (uint64_t)ApiFeature::ALL_FEATURES; }
+
     void onLocoSpeedChange(const LocoHandle& loco, float speedPercent, Direction direction, int speedSteps) override {
 #if USE_EXTENDED_CLI_SYNTAX
         _stream->print("<THROTTLE cab=\"");
@@ -226,6 +228,8 @@ private:
 class XmlPrinter : public IUnifiedModelTrainListener {
 public:
     XmlPrinter(Stream& stream) : _stream(&stream) {}
+
+    uint64_t getImplementedApi() const override { return (uint64_t)ApiFeature::ALL_FEATURES; }
 
     // Helper to start the XML document
     void begin() {


### PR DESCRIPTION
Introduces a mechanism for runtime self-inspection of classes implementing the `IUnifiedModelTrainListener` interface.

Key changes:
-   Added a new `ApiFeature` enum bitmask in `xDuinoRails_xTrainAPI.h` to represent each API function.
-   Converted all pure virtual functions in `IUnifiedModelTrainListener` to virtual functions with default empty implementations. This makes implementing the interface more flexible, as classes are no longer required to override every function.
-   Added a new `getImplementedApi()` virtual function to the interface, allowing classes to return a bitmask of the features they implement.
-   Updated the `CmdLinePrinter` and `XmlPrinter` utility classes to correctly override the new function and report that they implement all API features.