### PR TITLE
Add MkDocs to build pipeline and deploy to gh-pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           files: release-assets/*
 
   build-and-deploy-docs:
-    # NOTE: This job correctly generates the Doxygen and Redocly/Swagger
+    # NOTE: This job correctly generates the MkDocs, Doxygen and Redocly/Swagger
     # documentation and deploys it to the 'gh-pages' branch. If the documentation
     # links in the README are broken, the repository's GitHub Pages settings
     # must be configured to serve from the 'gh-pages' branch.
@@ -124,8 +124,26 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs
+        run: pip install mkdocs
+
       - name: Install Redocly CLI
         run: npm install -g @redocly/cli
+
+      - name: Prepare MkDocs source
+        run: |
+          mkdir -p site_source/docs
+          cp *.en.md site_source/
+          cp docs/*.en.md site_source/docs/
+          mv site_source/README.en.md site_source/index.md
+
+      - name: Build MkDocs site
+        run: mkdocs build
 
       - name: Create Doxygen output directory
         run: mkdir -p public/doxygen
@@ -143,23 +161,6 @@ jobs:
 
       - name: Copy webtool to public directory
         run: cp -r webtool public/
-
-      - name: Create index page
-        run: |
-          echo '<!DOCTYPE html>
-          <html>
-          <head>
-            <title>xTrain API Documentation</title>
-          </head>
-          <body>
-            <h1>xTrain API Documentation</h1>
-            <ul>
-              <li><a href="doxygen/index.html">Doxygen (C++ API)</a></li>
-              <li><a href="swagger/index.html">Redocly (REST API)</a></li>
-              <li><a href="webtool/index.html">Web Tool</a></li>
-            </ul>
-          </body>
-          </html>' > public/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 server.log
+site_source/
+public/
+site/

--- a/docs/API_LINKS.de.md
+++ b/docs/API_LINKS.de.md
@@ -1,0 +1,5 @@
+# API Referenz
+
+*   [C++ API (Doxygen)](https://chatelao.github.io/xDuinoRails_xTrainAPI/doxygen/index.html)
+*   [REST API (Swagger)](https://chatelao.github.io/xDuinoRails_xTrainAPI/swagger/index.html)
+*   [Web Tool](https://chatelao.github.io/xDuinoRails_xTrainAPI/webtool/index.html)

--- a/docs/API_LINKS.en.md
+++ b/docs/API_LINKS.en.md
@@ -1,0 +1,5 @@
+# API Reference
+
+*   [C++ API (Doxygen)](https://chatelao.github.io/xDuinoRails_xTrainAPI/doxygen/index.html)
+*   [REST API (Swagger)](https://chatelao.github.io/xDuinoRails_xTrainAPI/swagger/index.html)
+*   [Web Tool](https://chatelao.github.io/xDuinoRails_xTrainAPI/webtool/index.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: xTrain API
+site_url: https://chatelao.github.io/xDuinoRails_xTrainAPI/
+repo_url: https://github.com/chatelao/xDuinoRails_xTrainAPI
+theme:
+  name: readthedocs
+
+docs_dir: site_source
+site_dir: public
+
+nav:
+  - Home: index.md
+  - CLI Syntax: docs/CLI_SYNTAX.en.md
+  - Glossary: XTTRAIN_GLOSSARY.en.md
+  - Data Dictionary: DATA_DICTIONARY.en.md
+  - Open Issues: OPEN_ISSUES.en.md
+  - API Reference: docs/API_LINKS.en.md


### PR DESCRIPTION
Integrated MkDocs into the GitHub Actions workflow to generate a static documentation site.
- Added `mkdocs.yml` configuration using the `readthedocs` theme.
- Updated `.github/workflows/build.yml` to install MkDocs, consolidate documentation files into a staging directory, and build the site.
- Replaced the manual `index.html` generation with the MkDocs build.
- Added `docs/API_LINKS.en.md` and `.de.md` to link to Doxygen, Swagger, and Webtool artifacts.
- Updated `.gitignore` to exclude build artifacts.